### PR TITLE
377 replies on comment multiplies

### DIFF
--- a/frontend/src/components/comment/index.js
+++ b/frontend/src/components/comment/index.js
@@ -63,8 +63,8 @@ class Comment extends Component {
   }
 
   onReplyAdd = () => {
-    this.setState({ showReplies: true })
     this.props.onReplyAdd()
+    this.setState({ showReplies: true })
   }
 
   onReplyClick = () => {

--- a/frontend/src/components/comment/index.js
+++ b/frontend/src/components/comment/index.js
@@ -63,8 +63,8 @@ class Comment extends Component {
   }
 
   onReplyAdd = () => {
-    this.props.onReplyAdd()
     this.setState({ showReplies: true })
+    this.props.onReplyAdd()
   }
 
   onReplyClick = () => {


### PR DESCRIPTION
closes #377 

<br />

 **What is it supposed to do**  
Fixes an issue with sub-comments on comments multiplying when there are 2 or more comments. Was caused by wrong state management in the loading function.

<br />

 **How can we test your branch**  
- [ ] Go to a post while logged in
- [ ] Place two comments
- [ ] Comment on one of the comments
- [ ] The comment should state that there is 1 sub-comment, instead of 2 or more

<br />

 **Additional notes**  
This branch does not solve the remaining issue with comments not unfolding anymore (since the re-render is still forced by resetting the state).

<br />

**1. General checklist**
- [x] a. Tested happy flow.
- [x] b. Tested unhappy flow.
- [x] c. No unexpected exceptions.
- [x] d. No code with high complexity. (Big O)
- [x] e. EOF newline.
- [x] f. No linter warnings or errors.

<br />

**2. If relevant, front-end checklist**
- [x] a. Responsive. (Desktop all the way to mobile 320px)
- [x] b. Using SCSS variables where relevant.
- [x] c. Relevant class names
- [x] d. No modified global SCSS properties, except if necessary and fully tested the impact.
- [x] e. Checked [caniuse](https://caniuse.com) for more modern CSS properties.

<br />

**4. If relevant, test these browsers**
- [x] a. Chrome
- [ ] b. Firefox
- [ ] c. Opera
- [ ] d. Edge
- [ ] e. Safari
