### PR TITLE
397 admin delete comments

### DIFF
--- a/backend/src/controllers/comment.controller.ts
+++ b/backend/src/controllers/comment.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, NotFoundException, Param, Patch, Post } from '@nestjs/common'
+import { Body, Controller, Delete, Get, NotFoundException, Param, Patch, Post, UseGuards } from '@nestjs/common'
 import { ApiTags } from '@nestjs/swagger'
 import { CommentService } from '../services/comment.service'
 import { Comment } from '../entities/comment.entity'
@@ -6,6 +6,7 @@ import { CommentDTO } from '../dtos/comment.dto'
 import { AuthorizedUser } from '../decorators/jwt.decorator'
 import { Account } from '../entities/account.entity'
 import { AllowAny } from '../decorators/allow-any.decorator'
+import { hasPermission } from '../guards/roles.guard'
 
 @ApiTags('Comment')
 @Controller('comment')
@@ -67,7 +68,18 @@ export class CommentController {
 
   @Delete('/:id')
   public async deleteComment(@Param('id') comment_id: number, @AuthorizedUser() user: Account): Promise<string> {
-    await this.commentService.deleteComment(comment_id, user.profile)
+    await this.commentService.deleteComment(comment_id, user.profile, true)
+
+    return 'Successfully deleted comment'
+  }
+
+  @Delete('/:id/moderator')
+  @UseGuards(hasPermission('REMOVE_COMMENTS'))
+  public async deleteCommentModerator(
+      @Param('id') comment_id: number,
+      @AuthorizedUser() user: Account
+  ): Promise<string> {
+    await this.commentService.deleteComment(comment_id, user.profile, false)
 
     return 'Successfully deleted comment'
   }

--- a/backend/src/modules/comment.module.ts
+++ b/backend/src/modules/comment.module.ts
@@ -6,13 +6,15 @@ import { CommentRepository } from '../repositories/comment.repository'
 import { PostRepository } from '../repositories/post.repository'
 import { AuthModule } from './auth.module'
 import { ProfileCommentLikeRepository } from '../repositories/profile_comment_like.repository'
+import { RolePermissionRepository } from '../repositories/role_permission.repository'
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
       CommentRepository,
       PostRepository,
-      ProfileCommentLikeRepository
+      ProfileCommentLikeRepository,
+      RolePermissionRepository
     ]),
     AuthModule
   ],

--- a/backend/src/seeding/data/seed.data.ts
+++ b/backend/src/seeding/data/seed.data.ts
@@ -13,6 +13,7 @@ export const permissionsModerators = [
   'REMOVE_POSTS',
   'RECOVER_POSTS',
   'SEE_REPORTED_POSTS',
+  'REMOVE_COMMENTS',
   'VIEW_TICKETS',
   'CONTENT_BLOCK_USERS',
   'COMMENT_BLOCK_USERS',

--- a/backend/src/services/comment.service.ts
+++ b/backend/src/services/comment.service.ts
@@ -100,14 +100,16 @@ export class CommentService {
     await this.commentRespository.unpinCommentById(id)
   }
 
-  public async deleteComment(comment_id: number, profile: Profile): Promise<void> {
+  public async deleteComment(comment_id: number, profile: Profile, requireOwner: boolean): Promise<void> {
     const comment = await this.commentRespository.getCommentById(comment_id)
 
     if (!comment) throw new NotFoundException(`Comment to delete not found with id ${ comment_id }`)
 
     const commentProfile = await this.commentRespository.getCommentProfileById(comment.id)
 
-    if (commentProfile.display_name !== profile.display_name) {
+    const isOwner = commentProfile.display_name === profile.display_name
+
+    if (requireOwner && !isOwner) {
       throw new ForbiddenException()
     }
 

--- a/frontend/src/components/comment/index.js
+++ b/frontend/src/components/comment/index.js
@@ -31,6 +31,7 @@ class Comment extends Component {
     }
 
     this.isDeletingAsAdmin = false
+    this.COMMENT_ENDPOINT = `${ this.props.store.defaultData.backendUrl }/comment`
   }
 
   displayAvatar = () => {
@@ -79,7 +80,7 @@ class Comment extends Component {
 
   onDeleteConfirm = () => {
     const url =
-      `http://localhost:8000/api/comment/${ this.props.comment.id }${ this.isDeletingAsAdmin ? '/moderator' : '' }`
+      `${ this.COMMENT_ENDPOINT }/${ this.props.comment.id }${ this.isDeletingAsAdmin ? '/moderator' : '' }`
 
     axios
       .delete(url, { withCredentials: true })
@@ -96,7 +97,7 @@ class Comment extends Component {
   }
 
   onLikeClick = () => {
-    const url = `http://localhost:8000/api/comment/likes/${ this.props.comment.id }/`
+    const url = `${ this.COMMENT_ENDPOINT }/likes/${ this.props.comment.id }/`
     this.state.likes.profileHasLiked ? this.onUnlikeComment(url) : this.onLikeComment(url)
   }
 
@@ -128,7 +129,7 @@ class Comment extends Component {
   }
 
   onPinClick = () => {
-    const url = `http://localhost:8000/api/comment/${ this.props.comment.id }/${ this.state.isPinned ? 'un' : '' }pin`
+    const url = `${ this.COMMENT_ENDPOINT }/${ this.props.comment.id }/${ this.state.isPinned ? 'un' : '' }pin`
 
     axios.patch(url, null, { withCredentials: true })
       .then(() => {

--- a/frontend/src/components/comment/index.js
+++ b/frontend/src/components/comment/index.js
@@ -29,6 +29,8 @@ class Comment extends Component {
     if (this.props.comment && this.props.comment.parent_comment_id) {
       this.isReply = true
     }
+
+    this.isDeletingAsAdmin = false
   }
 
   displayAvatar = () => {
@@ -76,7 +78,8 @@ class Comment extends Component {
   }
 
   onDeleteConfirm = () => {
-    const url = `http://localhost:8000/api/comment/${ this.props.comment.id }`
+    const url =
+      `http://localhost:8000/api/comment/${ this.props.comment.id }${ this.isDeletingAsAdmin ? '/moderator' : '' }`
 
     axios
       .delete(url, { withCredentials: true })
@@ -162,7 +165,12 @@ class Comment extends Component {
     const { comment } = this.props
     const { profile } = this.props.store
 
-    if (comment.profile.display_name === profile.display_name) {
+    const isOwner = comment.profile.display_name === profile.display_name
+    const isAdmin = profile.loggedIn && profile.role.toUpperCase() !== 'USER'
+
+    this.isDeletingAsAdmin = isAdmin
+
+    if (isOwner || isAdmin) {
       return (
           <>
             <Icon


### PR DESCRIPTION
closes #397 

<br />

 **What is it supposed to do**  
Allows moderators (or higher) to delete comments owned by other users. A new route is created; "../id/moderator", which checks the sender's permissions.

<br />

 **How can we test your branch**  
Run _npm run reset_ to get the changes to the permissions.
Create a post with a new account without moderator privileges and comment on it.
Then log in to the admin account and see if you can delete the comment.
Do note that you might need to refresh before being able to see the delete button, since the fix for this is in #396.

<br />

**1. General checklist**
- [x] a. Tested happy flow.
- [x] b. Tested unhappy flow.
- [x] c. No unexpected exceptions.
- [x] d. No code with high complexity. (Big O)
- [x] e. EOF newline.
- [x] f. No linter warnings or errors.

<br />

**2. If relevant, front-end checklist**
- [x] a. Responsive. (Desktop all the way to mobile 320px)
- [x] b. Using SCSS variables where relevant.
- [x] c. Relevant class names
- [x] d. No modified global SCSS properties, except if necessary and fully tested the impact.
- [x] e. Checked [caniuse](https://caniuse.com) for more modern CSS properties.

<br />

**3. If relevant, back-end checklist**
- [x] a. No unhandled promise rejections.
- [x] b. Seeders still functional.
- [x] c. No primary-key violations.
- [x] d. Normalization, at least [3NF](https://en.wikipedia.org/wiki/Database_normalization).
- [x] e. Used guards (middleware) where necessary and tested if route is guarded.
